### PR TITLE
basic register approach

### DIFF
--- a/lib/presto.rb
+++ b/lib/presto.rb
@@ -1,7 +1,9 @@
 require "presto/engine"
 require 'presto/config/model'
-require 'formtastic'
 require 'presto/settings'
+require "presto/registers/register"
+
+require 'formtastic'
 require 'will_paginate'
 require 'will_paginate-bootstrap'
 require 'haml'

--- a/lib/presto.rb
+++ b/lib/presto.rb
@@ -13,6 +13,8 @@ module Presto
   def self.setup
     yield self
   end
+  Register.find_definitions
+
   class PrestoRailtie < Rails::Railtie
     initializer "new_initialization_behavior" do |app|
       app.routes.append do

--- a/lib/presto/load_relationships_attributes.rb
+++ b/lib/presto/load_relationships_attributes.rb
@@ -30,7 +30,14 @@ module Presto
         @resp["#{relationship.plural_name}_attributes".to_sym] = attributes
       end
 
-      self.send("#{relationship.macro}_attributes".to_sym, relationship) if Presto.module_eval("load_#{relationship.macro}_relationships")
+      #if Presto.module_eval("load_#{relationship.macro}_relationships")
+      if Presto.registry.has_key?(relationship.active_record.to_s.downcase.to_sym) #Return the Model name as a sym e.g: :post, :comment
+        if Presto.registry[relationship.active_record.to_s.downcase.to_sym]["load_#{relationship.macro}_relationships".to_sym]
+          self.send("#{relationship.macro}_attributes".to_sym, relationship)
+        end
+      elsif Presto.module_eval("load_#{relationship.macro}_relationships")
+        self.send("#{relationship.macro}_attributes".to_sym, relationship)
+      end
     end
   end
 end

--- a/lib/presto/registers/register.rb
+++ b/lib/presto/registers/register.rb
@@ -3,20 +3,37 @@ module Presto
   @@registry = {}
 
   class Register
+    cattr_accessor :definition_file_paths
+    self.definition_file_paths = %w(app/presto_admin/registers app/models/presto_admin_registers)
+
     def self.register(&block)
       self.new.instance_eval(&block)
     end
 
     def add(klass, config = {})
-      Presto.registry[klass.to_s.downcase.to_sym] = config
+      Presto.registry[klass] = config
     end
+
+    def self.find_definitions
+      absolute_definition_file_paths = definition_file_paths.map { |path| File.expand_path(path) }
+      absolute_definition_file_paths.uniq.each do |path|
+        load("#{path}.rb") if File.exist?("#{path}.rb")
+
+        if File.directory? path
+          Dir[File.join(path, '**', '*.rb')].sort.each do |file|
+            load file
+          end
+        end
+      end
+    end
+
   end
 end
 
 # Asi seria como agregarian las configuraciones por modelo
 #
 # Presto::Register.register do
-#   add Post, {
+#   add :post, {
 #     load_has_many_relationships: true
 #   }
 # end

--- a/lib/presto/registers/register.rb
+++ b/lib/presto/registers/register.rb
@@ -1,0 +1,22 @@
+module Presto
+  mattr_accessor :registry
+  @@registry = {}
+
+  class Register
+    def self.register(&block)
+      self.new.instance_eval(&block)
+    end
+
+    def add(klass, config = {})
+      Presto.registry[klass.to_s.downcase.to_sym] = config
+    end
+  end
+end
+
+# Asi seria como agregarian las configuraciones por modelo
+#
+# Presto::Register.register do
+#   add Post, {
+#     load_has_many_relationships: true
+#   }
+# end


### PR DESCRIPTION
# WORK IN PROGRESS 
### DO NOT MERGE YET

La forma en la que funciona ahora se debe agregar lo siguente: 
```ruby
Presto::Register.register do
  add :post, {
    load_has_many_relationships: true
  }
end
```
Donde el metodo ```add``` recibe dos parametros, un simbolo de el nombre del Model y un hash con las configuraciones que se quieren.

Esto va a guardar en Prest.registry un hash de la siguiente forma:
```ruby
{
post: {
  load_has_many_relationships: true
 }
}
```